### PR TITLE
Clean-up of obsolete code preventing load on 'beta' branch 211.15

### DIFF
--- a/Mod/src/Parts/PickupGear.cs
+++ b/Mod/src/Parts/PickupGear.cs
@@ -47,7 +47,7 @@ namespace XRL.World.Parts {
 
         public override bool WantTurnTick() => true;
 
-        public override void TurnTick(long TurnNumber) {
+        public override void TurnTick(long TurnTick, int Amount) {
             if (ParentObject.IsBusy()) {
                 return;
             }
@@ -56,7 +56,7 @@ namespace XRL.World.Parts {
                 return;
             }
 
-            Utility.MaybeLog("Turn " + TurnNumber);
+            Utility.MaybeLog("Turn " + TurnTick);
 
             // Primary weapon
             if (ParentObject.IsCombatObject() &&

--- a/Mod/src/Parts/Unburden.cs
+++ b/Mod/src/Parts/Unburden.cs
@@ -17,7 +17,7 @@ namespace XRL.World.Parts {
 
         public override bool WantTurnTick() => true;
 
-        public override void TurnTick(long TurnNumber) {
+        public override void TurnTick(long TurnTick, int Amount) {
             var excess = ParentObject.Body.GetWeight() + ParentObject.Inventory.GetWeight() - ParentObject.GetMaxCarriedWeight();
             if (excess <= 0) {
                 return;


### PR DESCRIPTION
Switched obsolete TurnTick(long) -> TurnTick(long int) in two files; a recent changed on the beta branch are breaking the use of that specific obsolete method.

changes maintain back-compat to 210.24 ('main' branch)